### PR TITLE
Adds nginx_log_group

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,3 +1,4 @@
+---
 extends: default
 
 rules:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Role Variables
   - `nginx_worker_connections`: sets the maximum number of simultaneous connections that can be opened by a worker process (default: 1024)
   - `nginx_mode`: whether we'll run php5-fpm (default: php5-fpm)
   - `nginx_add_default`: do we add a default vhost (default: yes)
+  - `nginx_log_group`: unix group to use when creating log files after rotateion (default: "adm")
 
 Tags
 ----

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 nginx_add_default: no
 nginx_ie8_support: yes
 nginx_keepalive_timeout: 75s
+nginx_log_group: adm
 nginx_map_hash_bucket_size: 128
 nginx_multi_accept: "on"
 nginx_root: /var/lib/nginx/

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -37,3 +37,6 @@
     src: logrotate_nginx.j2
     dest: /etc/logrotate.d/nginx
     mode: 0644
+  tags:
+    - nginx:logrotate
+    - nginx:logs

--- a/templates/logrotate_nginx.j2
+++ b/templates/logrotate_nginx.j2
@@ -7,7 +7,7 @@
   compress
   delaycompress
   notifempty
-  create 0640 www-data adm
+  create 0640 www-data {{ nginx_log_group }}
   sharedscripts
   prerotate
     if [ -d /etc/logrotate.d/httpd-prerotate ]; then \


### PR DESCRIPTION
Added nginx_log_group variable so group ownership of log files can be
set.
This lets non-privileged users in the proper group access log files for
reading.

@devops-works/admins 